### PR TITLE
Fix accidental double-bump of version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pagerduty"
-version = "2.2.0"
+version = "2.1.0"
 description = "Clients for PagerDuty's Public APIs"
 requires-python = ">=3.6"
 dependencies = ["certifi", "requests", "urllib3"]


### PR DESCRIPTION
The last pull request already included a minor version increment to 2.1.0 which I later bumped to 2.2.0 (unnecessary).