### PR TITLE
Fix bug: main method called from wrapper script cannot require arguments

### DIFF
--- a/pagerduty/cli.py
+++ b/pagerduty/cli.py
@@ -8,7 +8,7 @@ from .events_api_v2_client import EventsApiV2Client
 HOSTNAME = socket.gethostname()
 DEFAULT_SOURCE = f"pagerduty.cli on {HOSTNAME}"
 
-def main(argv):
+def run(argv):
     parser = argparse.ArgumentParser(
         description='PagerDuty Events API V2 Command Line Interface'
     )
@@ -53,5 +53,8 @@ def main(argv):
         print(f"Error: {str(e)}", file=sys.stderr)
         sys.exit(1)
 
+def main():
+    run(sys.argv[1:])
+
 if __name__ == '__main__':
-    main(sys.argv[1:])
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pagerduty"
-version = "2.1.0"
+version = "2.1.1"
 description = "Clients for PagerDuty's Public APIs"
 requires-python = ">=3.6"
 dependencies = ["certifi", "requests", "urllib3"]

--- a/tests/cli_test.py
+++ b/tests/cli_test.py
@@ -8,7 +8,7 @@ class CliTest(unittest.TestCase):
 
     @patch.object(pagerduty.EventsApiV2Client, 'trigger')
     def test_trigger(self, trigger_method):
-        cli.main([
+        cli.run([
             '-k', 'routing_key_here',
             '-i', 'dedup_key_here',
             '--description', 'description_here',
@@ -21,7 +21,7 @@ class CliTest(unittest.TestCase):
 
     @patch.object(pagerduty.EventsApiV2Client, 'acknowledge')
     def test_acknowledge(self, acknowledge_method):
-        cli.main([
+        cli.run([
             '-k', 'routing_key_here',
             '-i', 'dedup_key_here',
             'acknowledge'
@@ -30,7 +30,7 @@ class CliTest(unittest.TestCase):
 
     @patch.object(pagerduty.EventsApiV2Client, 'resolve')
     def test_resolve(self, resolve_method):
-        cli.main([
+        cli.run([
             '-k', 'routing_key_here',
             '-i', 'dedup_key_here',
             'resolve'


### PR DESCRIPTION
In an ASDF-managed environment, it was observed that the script runs into an error related to the requirement that the main method take the list of command line arguments as its one argument, whereas the wrapper that runs it sends it no arguments.

This adjusts the CLI module to account for this.