### PR TITLE
Fix `callable` type annotations on decorators and parameters

### DIFF
--- a/pagerduty/common.py
+++ b/pagerduty/common.py
@@ -1,6 +1,7 @@
 # Core
+import functools
 from datetime import datetime, timedelta, timezone
-from typing import List, Optional, Tuple, Union
+from typing import Any, Callable, List, Optional, Tuple, Union
 from warnings import warn
 from json.decoder import JSONDecodeError
 
@@ -213,18 +214,17 @@ def relative_seconds_to_datetime(seconds_remaining: int) -> str:
     return strftime(target_time)
 
 
-def requires_success(method: callable) -> callable:
+def requires_success(method: Callable[..., Any]) -> Callable[..., Any]:
     """
     Decorator that validates HTTP responses.
 
     Uses :attr:`pagerduty.common.successful_response` for said validation.
     """
-    doc = method.__doc__
 
+    @functools.wraps(method)
     def call(self, url, **kw):
         return successful_response(method(self, url, **kw))
 
-    call.__doc__ = doc
     return call
 
 

--- a/pagerduty/rest_api_v2_base_client.py
+++ b/pagerduty/rest_api_v2_base_client.py
@@ -1,6 +1,15 @@
 # Core
+import functools
 from copy import deepcopy
-from typing import Iterator, List, Optional, Tuple, Union
+from typing import (
+    Any,
+    Callable,
+    Iterator,
+    List,
+    Optional,
+    Tuple,
+    Union,
+)
 from warnings import warn
 
 # PyPI
@@ -360,7 +369,7 @@ def unwrap(response: Response, wrapper: EntityWrapping) -> Union[dict, list]:
 ###########################
 
 
-def auto_json(method: callable) -> callable:
+def auto_json(method: Callable[..., Any]) -> Callable[..., Any]:
     """
     Decorator to return the full response body object after decoding from JSON.
 
@@ -369,16 +378,15 @@ def auto_json(method: callable) -> callable:
 
     The new return value is the JSON-decoded response body.
     """
-    doc = method.__doc__
 
+    @functools.wraps(method)
     def call(self, url, **kw):
         return try_decoding(successful_response(method(self, url, **kw)))
 
-    call.__doc__ = doc
     return call
 
 
-def resource_url(method: callable) -> callable:
+def resource_url(method: Callable[..., Any]) -> Callable[..., Any]:
     """
     API call decorator that allows passing a resource dict as the path/URL
 
@@ -389,9 +397,9 @@ def resource_url(method: callable) -> callable:
     such a resource dictionary as the ``path`` argument, thus eliminating the
     need to re-construct the resource URL or hold it in a temporary variable.
     """
-    DOC = method.__doc__
     NAME = method.__name__
 
+    @functools.wraps(method)
     def call(self, resource, **kw):
         url = resource
         if type(resource) is dict:
@@ -410,11 +418,10 @@ def resource_url(method: callable) -> callable:
             )
         return method(self, url, **kw)
 
-    call.__doc__ = DOC
     return call
 
 
-def wrapped_entities(method: callable) -> callable:
+def wrapped_entities(method: Callable[..., Any]) -> Callable[..., Any]:
     """
     Decorator to automatically wrap/unwrap request and response entities
 
@@ -444,8 +451,8 @@ def wrapped_entities(method: callable) -> callable:
         A callable object; the reformed method
     """
     HTTP_METHOD = method.__name__.lstrip("r")
-    DOC = method.__doc__
 
+    @functools.wraps(method)
     def call(self, url, **kw):
         pass_kw = deepcopy(kw)  # Make a copy for modification
         path = self.canonical_path(url)
@@ -466,7 +473,6 @@ def wrapped_entities(method: callable) -> callable:
         # Unpack the response:
         return unwrap(r, res_w)
 
-    call.__doc__ = DOC
     return call
 
 
@@ -733,7 +739,7 @@ class RestApiV2BaseClient(ApiClient):
         url,
         params: Optional[dict] = None,
         page_size: Optional[int] = None,
-        item_hook: Optional[callable] = None,
+        item_hook: Optional[Callable[..., Any]] = None,
         total: Optional[bool] = False,
     ) -> Iterator[dict]:
         """
@@ -894,7 +900,7 @@ class RestApiV2BaseClient(ApiClient):
         self,
         url: str,
         params: Optional[dict] = None,
-        item_hook: Optional[callable] = None,
+        item_hook: Optional[Callable[..., Any]] = None,
         page_size: Optional[int] = None,
     ) -> Iterator[dict]:
         """

--- a/tests/rest_api_v2_base_client_test.py
+++ b/tests/rest_api_v2_base_client_test.py
@@ -354,6 +354,34 @@ class FunctionDecoratorsTest(unittest.TestCase):
             do_http_things.mock_calls[0][2]["json"], {"incidents": incidents}
         )
 
+    def test_decorators_preserve_function_metadata(self):
+        client = new_rest_api_v2_client()
+        decorated_methods = [
+            "jget",
+            "jpost",
+            "jput",
+            "rget",
+            "rpost",
+            "rput",
+            "rdelete",
+            "rpatch",
+        ]
+        for name in decorated_methods:
+            method = getattr(client, name)
+            self.assertEqual(
+                method.__name__,
+                name,
+                f"{name} lost its __name__ after decoration",
+            )
+            self.assertIsNotNone(
+                method.__doc__,
+                f"{name} lost its __doc__ after decoration",
+            )
+            self.assertTrue(
+                hasattr(method, "__wrapped__"),
+                f"{name} missing __wrapped__ (functools.wraps not applied)",
+            )
+
 
 class RestApiV2BaseClientTest(ClientTest):
     def test_auth_method(self):


### PR DESCRIPTION
This PR fixes `callable? not callable [misc]` mypy errors that downstream users hit when calling any of the library's decorated methods.

The four decorator functions (`auto_json`, `resource_url`, `wrapped_entities`, `requires_success`) and the `item_hook` parameter on `iter_all`/`iter_cursor` used lowercase `callable` as a type annotation. `callable` is the builtin function — not a type — so mypy infers `type[bool] | None`, making every decorated method (`jget`, `jpost`, `rget`, etc.) appear potentially `None` to type checkers.

- Replace `callable` with `Callable[..., Any]` across all six annotation sites in `common.py` and `rest_api_v2_base_client.py`
- Fix `item_hook: Optional[callable]` → `Optional[Callable[..., Any]]` on `iter_all` and `iter_cursor`
- Replace manual `call.__doc__ = method.__doc__` with `@functools.wraps` in all four decorators, also preserving `__name__`, `__qualname__`, and `__wrapped__`
- Add `test_decorators_preserve_function_metadata` verifying metadata propagation across all eight decorated public methods

Resolves #80